### PR TITLE
Remove readme instruction about editing server.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,11 @@
 mbtiles-server
 ==============
 
-Wow. It's really easy to serve mbtiles files without having to host them with Mapbox, just serve them yourself.  
+Wow. It's really easy to serve mbtiles files without having to host them with Mapbox, just serve them yourself.
 
-First, just create an mbtiles file (via Tilemill probably cause it's freaking amazing) and change line 4 of server.js to match your mbtile filename. 
+First, just create an mbtiles file (via Tilemill probably cause it's freaking amazing), then:
 
-Then: 
+1. `npm install`
+1. `node server.js [tilefile]`
 
-> npm install
-
-> node server.js [tilefile]
-
-visit [http://localhost:3000/3/1/2.png](http://localhost:3000/3/1/2.png)
+Visit [http://localhost:3000/3/1/2.png](http://localhost:3000/3/1/2.png)

--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
-var app = require('express').createServer(),
-  MBTiles = require('mbtiles');
-
+var express = require("express"),
+    app = express(),
+    MBTiles = require('mbtiles');
 
 if(process.argv.length < 3) {
   console.log("Error! Missing TILES filename.\nUsage: node server.js TILES");


### PR DESCRIPTION
It's no longer necessary now that the tiles location is passed via command line.
