### PR TITLE
getTile argument order

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,7 +4,7 @@ var express = require("express"),
 
 if(process.argv.length < 3) {
   console.log("Error! Missing TILES filename.\nUsage: node server.js TILES");
-  process.exit(1)
+  process.exit(1);
 }
 
 var TILES = String(process.argv[2]).replace(/\.mbtiles/,'') + '.mbtiles';
@@ -13,12 +13,12 @@ new MBTiles(__dirname + '/' + TILES, function(err, mbtiles) {
   if (err) throw err;
   app.get('/:y/:x/:z.*', function(req, res) {
     // .getTile() expects XYZ.
-    console.log(req.param('y'), req.param('x'), req.param('z'))
-    mbtiles.getTile(req.param('y'), req.param('x'), req.param('z'), function(err, tile, headers) {
+    console.log(req.param('z'), req.param('x'), req.param('y'));
+    mbtiles.getTile(req.param('z'), req.param('x'), req.param('y'), function(err, tile, headers) {
       if (err) {
         res.send('Tile rendering error: ' + err + '\n');
       } else {
-        res.header("Content-Type", "image/png")
+        res.header("Content-Type", "image/png");
         res.send(tile);
       }
     });


### PR DESCRIPTION
Thanks for this - it was exactly what I was looking for! One thing I had a problem with is the argument order for getTile. You have it as y,x,z, but the mbtiles.prototype.getTile spec has it as z,x,y. Since Leaflet uses the same alpha names for its layer parameters, it threw me for a bit. I could always remap the order in the client request, but since they use the same letters (i.e. `http://localhost:3000/{y}/{x}/{z}.png`) it feels dirty.

Not a big deal, just thought I'd let you know. 

Incidentally, any idea if there would be a problem tacking on a mbtiles name in the url route in case you have more than one tile set, like: 

```
var express = require("express"),
    app = express(),
    MBTiles = require('mbtiles');


app.get('/:s/:y/:x/:z.*', function(req, res) {
    new MBTiles(__dirname + '\\' + req.param('s') + '.mbtiles', function(err, mbtiles) {
        mbtiles.getTile(req.param('z'), req.param('x'), req.param('y'), function(err, tile, headers) {
            if (err) {
                res.send('Tile rendering error: ' + err + '\n');
            } else {
                res.header("Content-Type", "image/png");
                res.send(tile);
            }
        });
        if (err) console.log("error");
    });
});

console.log('Listening on port: ' + 3000);
app.listen(3000);
```

Seems to work fine, but I don't know if I'm losing some performance shiny by having more than one .mbtiles db per listener (wouldn't think so being node and all, but I'm a node noob). 
